### PR TITLE
fix(ios): UIScene-safe viewController; bump deployment target to 13.0

### DIFF
--- a/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
+++ b/ios/Classes/SwiftFlutterBarcodeScannerPlugin.swift
@@ -13,8 +13,25 @@ enum ScanMode:Int{
 }
 
 public class SwiftFlutterBarcodeScannerPlugin: NSObject, FlutterPlugin, ScanBarcodeDelegate,FlutterStreamHandler {
-    
-    public static var viewController = UIViewController()
+
+    // Resolved at access time so we work under the UIScene lifecycle that
+    // Flutter adopted in 3.32+. Under UIScene, AppDelegate has no `window`
+    // (it lives on UIWindowScene), so the previous force-unwrap in
+    // register(with:) crashed with EXC_BAD_INSTRUCTION on launch.
+    public static var viewController: UIViewController {
+        if #available(iOS 13.0, *) {
+            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            let activeScene = scenes.first(where: { $0.activationState == .foregroundActive }) ?? scenes.first
+            if let window = activeScene?.windows.first(where: { $0.isKeyWindow }) ?? activeScene?.windows.first,
+               let rootVC = window.rootViewController {
+                return rootVC
+            }
+        }
+        if let rootVC = (UIApplication.shared.delegate?.window ?? nil)?.rootViewController {
+            return rootVC
+        }
+        return UIViewController()
+    }
     public static var lineColor:String=""
     public static var cancelButtonText:String=""
     public static var isShowFlashIcon:Bool=false
@@ -22,9 +39,8 @@ public class SwiftFlutterBarcodeScannerPlugin: NSObject, FlutterPlugin, ScanBarc
     public static var isContinuousScan:Bool=false
     static var barcodeStream:FlutterEventSink?=nil
     public static var scanMode = ScanMode.QR.index
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
-        viewController = (UIApplication.shared.delegate?.window??.rootViewController)!
         let channel = FlutterMethodChannel(name: "flutter_barcode_scanner", binaryMessenger: registrar.messenger())
         let instance = SwiftFlutterBarcodeScannerPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
@@ -554,9 +570,18 @@ class BarcodeScannerViewController: UIViewController {
     }
     
     var isLandscape: Bool {
-        return UIDevice.current.orientation.isValidInterfaceOrientation
-            ? UIDevice.current.orientation.isPortrait
-            : UIApplication.shared.statusBarOrientation.isPortrait
+        if UIDevice.current.orientation.isValidInterfaceOrientation {
+            return UIDevice.current.orientation.isPortrait
+        }
+        if #available(iOS 13.0, *),
+           let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive })
+            ?? UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene }).first {
+            return scene.interfaceOrientation.isPortrait
+        }
+        return true
     }
     
     private func launchApp(decodedURL: String) {

--- a/ios/flutter_barcode_scanner.podspec
+++ b/ios/flutter_barcode_scanner.podspec
@@ -17,6 +17,6 @@ A new Flutter plugin supports barcode scanning on both Android and iOS.
   s.resources = 'Assets/*.png'
   s.dependency 'Flutter'
 
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
   s.swift_version = '5.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Amol Gangadhare <amol.gangadhare@gmail.com>
 homepage: https://github.com/AmolGangadhare/flutter_barcode_scanner
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
   flutter: ">=1.12.0"
 
 dependencies:


### PR DESCRIPTION
The pre-existing register(with:) force-unwrapped
UIApplication.shared.delegate.window, which is nil under Flutter's UIScene lifecycle (Flutter 3.32+). The plugin crashed with EXC_BAD_INSTRUCTION at app launch on Flutter 3.41.

- Replace stored static viewController with a computed property that resolves the active UIWindowScene's root view controller at access time, with a fallback to the legacy AppDelegate.window path.
- Drop the broken assignment from register(with:); registration is now side-effect-free.
- Replace deprecated UIApplication.shared.statusBarOrientation with the windowScene.interfaceOrientation equivalent.
- Bump podspec ios.deployment_target from 12.0 to 13.0 (UIScene min).
- Widen pubspec SDK constraint to allow Dart 3.x callers.